### PR TITLE
Remove spec files from coverage reports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,14 @@ function runSpecs( specPath, coverage ) {
 		} );
 		return acc;
 	}, [] );
+	var specExclude = _.map( specPath, function ( p ) {
+		return path.join( p, '**/*' );
+	} );
 	return gulp
 		.src( specs, { read: false } )
-		.pipe( mocha( { R: 'spec', istanbul: coverage ? true : false } ) );
+		.pipe( mocha( { R: 'spec', istanbul: coverage ? {
+			x: specExclude
+		} : false } ) );
 }
 
 function setupProcess( processName, opts ) {


### PR DESCRIPTION
@arobson @ifandelse This attempts to auto exclude all spec files from istanbul coverage reports. It should def work for any project using default locations. It should also work for custom locations, but we may need to expose this at some point as a separate config.
