### PR TITLE
Feature descriptions and common-gulp behavior

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Alex Robson
+Copyright (c) 2015 LeanKit
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -187,11 +187,14 @@ We've discovered many of our node-only and OSS libs typically have the same task
 var bg = require( "biggulp/common-gulp" )( require( "gulp" ) );
 /*
 	Gives you the following tasks:
-	├── restartProcesses
+    ├─┬ ?
+    │ └── help
+    ├── about
     ├── continuous-test
     ├─┬ coverage
     │ └── format
-    ├── coverage-watch
+    ├─┬ coverage-watch
+    │ └── coverage
     ├─┬ default
     │ ├── coverage
     │ └── coverage-watch
@@ -199,13 +202,16 @@ var bg = require( "biggulp/common-gulp" )( require( "gulp" ) );
     │ └── jshint
     ├── help
     ├── jshint
+    ├── restartProcesses
     ├── show-coverage
     ├─┬ test
-    │ └── test-watch
-    ├── test-and-exit
+    │ └── coverage
+    ├─┬ test-and-exit
+    │ └── jshint
     ├── test-behavior
     ├── test-int
-    └── test-watch
+    ├─┬ test-watch
+    │ └── continuous-test
 */
 ```
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/LeanKit-Labs/biggulp",
   "dependencies": {
     "gulp-changed": "^1.2.1",
+    "gulp-help": "^1.6.0",
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.0",
     "gulp-spawn-mocha": "~2.0.1",

--- a/src/about.js
+++ b/src/about.js
@@ -1,4 +1,8 @@
 var gutil = require( "gulp-util" );
+var fs = require( "fs" );
+var path = require( "path" );
+var pkg = require( "../package.json" );
+var license = fs.readFileSync( path.join( __dirname, "..", "LICENSE" ) ).toString();
 var banner = [
 	"                                                                                ",
 	"                                   ..:/:..                                      ",
@@ -28,17 +32,22 @@ var banner = [
 	"       +mm.  smmo         dmy      dmh +mm:    :mm/ mmhhmh/    mmy ymd          ",
 	"       :mms: .hmd+:-:oho  /dmy+::+hmmh +mm:    :mm/ mms`+dmy-  mmy +mmo:        ",
 	"        :ydd  `/shdddho-   .+ydddh  hy /hh.    :hh: hho  `ohh+`hhs  /ydd+       ",
-	"                                                                                "
+	"                                                                                ",
+	"--------------------------------------------------------------------------------",
+	"    biggulp v" + pkg.version,
+	"--------------------------------------------------------------------------------",
+	"",
+	license
 ];
 
 module.exports = {
-	banner: function() {
+	print: function() {
 		// yay for brute-forcing colors onto the banner...?
 		var colorized = gutil.colors.green( banner.slice( 0, 19 ).join( "\n" ) );
 		colorized += "\n" + gutil.colors.white( banner[ 19 ].substring( 0, 37 ) );
 		colorized += gutil.colors.green( banner[ 19 ].substring( 37, 41 ) );
 		colorized += gutil.colors.white( banner[ 19 ].substring( 41, 80 ) ) + "\n";
 		colorized += gutil.colors.white( banner.slice( 20 ).join( "\n" ) );
-		return colorized;
+		gutil.log( colorized );
 	}
 };

--- a/src/common-gulp.js
+++ b/src/common-gulp.js
@@ -23,6 +23,12 @@ module.exports = function( gulp, cfg ) {
 	}
 
 	addTasksWithDescription( {
+		about: {
+			description: "Where'd all these tasks come from?",
+			fn: function() {
+				about.print();
+			}
+		},
 		"continuous-test": {
 			description: "Runs all tests in a watch-friendly manner.",
 			fn: function() {
@@ -54,12 +60,6 @@ module.exports = function( gulp, cfg ) {
 				return bg.format();
 			}
 		},
-		about: {
-			description: "Where'd all these tasks come from?",
-			fn: function() {
-				about.print();
-			}
-		},
 		jshint: {
 			description: "Lints your code. Warning: It might hurt your feelings. See Doug Crockford for free hugs.",
 			fn: function() {
@@ -73,11 +73,12 @@ module.exports = function( gulp, cfg ) {
 			}
 		},
 		test: {
-			description: "Alias for the test-watch task.",
-			deps: [ "test-watch" ]
+			description: "Alias for the coverage task.",
+			deps: [ "coverage" ]
 		},
 		"test-and-exit": {
 			description: "Runs all tests and exits.",
+			deps: [ "jshint" ],
 			fn: function() {
 				bg.testAllOnce();
 			}

--- a/src/common-gulp.js
+++ b/src/common-gulp.js
@@ -1,18 +1,4 @@
-var gutil = require( "gulp-util" );
-var pkg = require( "../package.json" );
-var help = require( "./help" );
-
-function calColWidth( x ) {
-	return x.map( function( s ) {
-			return s.length;
-		} ).sort( function( a, b ) {
-			return b - a;
-		} )[0] + 1;
-}
-
-function padCol( col, len ) {
-	return col + new Array( len - col.length ).join( " " );
-}
+var about = require( "./about" );
 
 module.exports = function( gulp, cfg ) {
 	var tasks;
@@ -23,6 +9,9 @@ module.exports = function( gulp, cfg ) {
 		Object.keys( config ).forEach( function( taskNm ) {
 			var args = [ taskNm ];
 			var task = config[ taskNm ];
+			if ( task.description ) {
+				args.push( task.description );
+			}
 			if ( task.deps ) {
 				args.push( task.deps );
 			}
@@ -65,24 +54,10 @@ module.exports = function( gulp, cfg ) {
 				return bg.format();
 			}
 		},
-		help: {
-			description: "I need somebody. HELP! Not just anybody. HELP! You know I need someone...",
+		about: {
+			description: "Where'd all these tasks come from?",
 			fn: function() {
-				gutil.log( help.banner() );
-				gutil.log( gutil.colors.white( "--------------------------------------" ) );
-				gutil.log( gutil.colors.white( "   biggulp", "v" + pkg.version, "- Available Tasks" ) );
-				gutil.log( gutil.colors.white( "--------------------------------------" ) );
-				var taskNames = Object.keys( tasks );
-				var colLen = calColWidth( taskNames );
-				taskNames.forEach( function( taskNm ) {
-					var task = tasks[taskNm];
-					var msg = gutil.colors.green( padCol( taskNm, colLen ), "- " );
-					msg += gutil.colors.blue( task.description );
-					if ( task.deps ) {
-						msg += gutil.colors.yellow( " (depends on:", task.deps + ")" );
-					}
-					gutil.log( msg );
-				} );
+				about.print();
 			}
 		},
 		jshint: {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,9 @@ function permuPath( dirs, globs ) {
 }
 
 module.exports = function( gulpRef, cfg ) {
-	var gulp = gulpRef;
+	var gulp = require( "gulp-help" )( gulpRef, {
+		aliases: [ "?" ]
+	} );
 	var options = _.defaults( cfg || {}, defaults );
 	var processesDefined = false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ module.exports = function( gulpRef, cfg ) {
 
 	function setupProcess( processName, opts ) {
 		processesDefined = true;
-		return processhost.startProcess( processName, {
+		return processhost.start( processName, {
 			command: opts.command || opts.cmd || "node" + cmdPostfix,
 			args: opts.arguments || opts.args || [],
 			stdio: opts.stdio || "inherits",

--- a/src/index.js
+++ b/src/index.js
@@ -53,9 +53,9 @@ module.exports = function( gulpRef, cfg ) {
 	}
 
 	function test( specs ) {
-		var s = _.isArray( specs ) ? specs : [ specs ];
+		specs = specs || defaults.specs;
 		return runSpecs( {
-			specs: s
+			specs: _.isArray( specs ) ? specs : [ specs ]
 		} );
 	}
 


### PR DESCRIPTION
- Allow descriptions to (optionally) be added for any task by passing a string description as the second argument to `gulp.task`. These can be displayed by calling `gulp help` or `gulp ?`.
- Added an `about` task that displays the LK banner, biggulp version, and the license
- Updated default common-gulp tasks:
  - `gulp test` now runs jshint, format, and coverage then exits
  - `gulp test-and-exit` now runs jshint before tests
  - `gulp` (default task) is still an alias to watch coverage
- Other things:
  - Fixed call to renamed `processhost` method (this was a bug)
  - Fixed `test` and `testOnce` so they could be called with default spec paths (this was a bug)
