### PR TITLE
Added noop error handler to prevent continuous tests from exiting on …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ module.exports = function( gulpRef, cfg ) {
 			specs: specs,
 			coverageExclude: coverageExclude,
 			coverage: _opt.coverage
-		} );
+		} ).on( "error", _.noop );
 	}
 
 	function testAllAndExit( opt ) {


### PR DESCRIPTION
…failed test

This seems to be the only place used by a watch. Can anyone confirm that?
