### PR TITLE
Speed up linting and formatting by using more specific paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.2.x
+ * Speed up linting and formatting by using a more specific sources glob
 
 ### 0.2.1
  * Fix defect that causing watch tasks to crash the process if a test failed

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ All of these can be changed, but without providing specific values for them, the
 	integrationSpecPaths: [ "./spec/integration" ],
 	specs: [ "**/*.spec.js" ],
 	watchPaths: [ "./src/**/*", "./spec/**/*", "./resource/**/*" ],
-	sourcePaths: [ "./src", "./resource" ],
-	sources: [ "**/*.js" ],
-	exclude: [ "!node_modules/**", "!coverage/**" ],
+	sources: [ "*.js", "{resource,src,spec}/**/*.js" ],
 	jscsCfgPath: ".jscsrc"
 }
  ```

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,8 @@ var defaults = {
 	integrationSpecPaths: [ "./spec/integration" ],
 	specs: [ "**/*.spec.js" ],
 	watchPaths: [ "./src/**/*", "./spec/**/*", "./resource/**/*" ],
-	sourcePaths: [ "./src", "./resource" ],
-	sources: [ "**/*.js" ],
+	sources: [ "*.js", "{resource,src,spec}/**/*.js" ],
 	coverageHtml: "./coverage/lcov-report/index.html",
-	exclude: [ "!node_modules/**", "!coverage/**" ],
 	jscsCfgPath: ".jscsrc"
 };
 var jshint = require( "gulp-jshint" );
@@ -186,7 +184,7 @@ module.exports = function( gulpRef, cfg ) {
 
 	function format( opt ) {
 		var _opt = opt || options;
-		return gulp.src( _opt.sources.concat( _opt.exclude ) )
+		return gulp.src( _opt.sources )
 			.pipe( jscs( {
 				configPath: _opt.jscsCfgPath,
 				fix: true
@@ -201,7 +199,7 @@ module.exports = function( gulpRef, cfg ) {
 
 	function lint( opt ) {
 		var _opt = opt || options;
-		return gulp.src( _opt.sources.concat( _opt.exclude ) )
+		return gulp.src( _opt.sources )
 			.on( "error", function( error ) {
 				gutil.log( gutil.colors.red( error.message + " in " + error.fileName ) );
 				this.end();


### PR DESCRIPTION
We found that we could get a considerable speed boost in linting and formatting by being more specific about the files being included. Including all js files and then excluding `node_modules` and other paths takes `gulp.src` considerably longer.
- removed `sourcePaths` as it did not seem to be used
- updated `sources` default to be more specific
- removed `exclude`, as the `format` and `lint` tasks no longer need that option

We are also using `gulp-file-cache` to only lint/format changed files, but I did not include that in this PR, as it writes a cache file that would need to be added to any projects `.gitignore`.  This functionality can easily be added, if it is desired.

As an example, here is running `gulp format` on `seriate`:

Before:

```
[15:25:56] Starting 'jshint'...
[15:25:57] Finished 'jshint' after 1.02 s
[15:25:57] Starting 'format'...
[15:25:58] Finished 'format' after 908 ms
```

After:

```
[15:26:20] Starting 'jshint'...
[15:26:21] Finished 'jshint' after 456 ms
[15:26:21] Starting 'format'...
[15:26:21] Finished 'format' after 367 ms
```
