### PR TITLE
Updated gulp-jscs dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.2.x
+
  * Speed up linting and formatting by using a more specific sources glob
+ * Updated gulp-jscs dependency
 
 ### 0.2.1
  * Fix defect that causing watch tasks to crash the process if a test failed

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "gulp-changed": "^1.2.1",
     "gulp-help": "^1.6.0",
-    "gulp-jscs": "^1.6.0",
+    "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^1.11.0",
     "gulp-spawn-mocha": "~2.0.1",
     "gulp-util": "^3.0.6",


### PR DESCRIPTION
Newer version of jscs has a json reporter, which is required by the jscs plugin for vim.
